### PR TITLE
shinyTools 24.12.0: update links and logos in headerUI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shinyTools
 Type: Package
 Title: Tools for Shiny Apps
-Version: 24.11.2
+Version: 24.12.0
 Authors@R: c(
             person("Lukas", "Fuchs", email = "lukas.fuchs@inwt-statistics.de", role = c("cre", "aut")),
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# shinyTools 24.12.0
+
+## Updates
+- _headerUI_: integration of new links, and logos loaded from the https://github.com/Pandora-IsoMemo/docs/blob/main/img/ folder
+
 # shinyTools 24.11.2
 
 ## Updates

--- a/R/02-headerButtons.R
+++ b/R/02-headerButtons.R
@@ -26,9 +26,25 @@ headerButtonsUI <- function(id, help_link, further_help_link = NULL) {
       div(
         id = "logo-isomemo",
         tags$a(
-          href = "https://isomemo.com/",
-          img(src = "https://github.com/Pandora-IsoMemo/docs/blob/main/img/isomemo-logo.png?raw=true", alt = "IsoMemo"),
+          href = "https://isomemo.gea.mpg.de/",
+          img(src = "https://github.com/Pandora-IsoMemo/docs/blob/main/img/isomemo-logo-white.png?raw=true", alt = "IsoMemo"),
           target = "_blank"
+        )
+      ),
+      div(
+        id = "logo-pandora",
+        tags$a(
+          href = "https://pandoradata.earth/",
+          img(src = "https://github.com/Pandora-IsoMemo/docs/blob/main/img/pandora-logo-white.png?raw=true", alt = "Pandora"),
+          target = "_blank"
+        )
+      ),
+      div(
+        id = "apps",
+        tags$button(
+          onclick = paste0("window.open('https://pandora-isomemo.github.io/docs/apps.html','_blank');"),
+          class = "btn btn-default",
+          "Apps"
         )
       ),
       # further help nur wenn nicht NULL argument

--- a/inst/dist/custom.css
+++ b/inst/dist/custom.css
@@ -61,28 +61,56 @@ h5 {
     z-index: 9999;
     overflow: hidden;
     display: inline;
+    align-items: center; /* Vertically center child elements */
+}
+
+#logo-mpi {
+    display: inline;
+    width: 150px;
+    height: 130px;
+    margin-right: 15px;
+}
+
+#logo-isomemo {
+    display: inline;
+    height: 50px;
+    width: 150px;
+    margin-right: 1px;
+}
+
+#logo-pandora {
+    display: inline;
+    height: 35px;
+    width: 150px;
+    margin-right: 10px;
 }
 
 #help {
     display:inline;
 }
 
-#logo-isomemo, #logo-mpi {
-    display: inline;
-    width: 150px;
-    height: 130px;
-    margin-right: 10px;
-}
-
-#logo-isomemo img {
-    height: 50px;
-    width: 75px;
-    border-radius: 2px;
+#apps {
+    display:inline;
 }
 
 #logo-mpi img {
     height: 50px;
     width: 57px;
+    margin-top: -5px;
+    border-radius: 2px;
+}
+
+#logo-isomemo img {
+    height: 50px;
+    width: 150px;
+    margin-top: 5px;
+    border-radius: 2px;
+}
+
+#logo-pandora img {
+    height: 40px;
+    width: 170px;
+    margin-top: -5px;
     border-radius: 2px;
 }
 
@@ -90,7 +118,7 @@ h5 {
     display: inline;
 }
 
-#help button, #further-help button {
+#help button, #further-help button, #apps button {
     padding: 3px 10px;
     background-color: #18bc9c;
     border-color: #0f7864;


### PR DESCRIPTION
# shinyTools 24.12.0

## Updates
- _headerUI_: integration of new links, and logos loaded from the https://github.com/Pandora-IsoMemo/docs/blob/main/img/ folder